### PR TITLE
Tweak to default E-Stop macro name

### DIFF
--- a/octoprint_klipper/__init__.py
+++ b/octoprint_klipper/__init__.py
@@ -56,7 +56,7 @@ class KlipperPlugin(
             replace_connection_panel=True
          ),
          macros = [dict(
-            name="E-Stop",
+            name="Emergency-Stop",
             macro="M112",
             sidebar=True,
             tab=True


### PR DESCRIPTION
Apologies for making such a tiny change, but this has always bugged me.

It took me embarrasingly long to figure out that "E-Stop" stands for
"Emergency-Stop" (my mind jumped straight to Extruder-Stop - which made
no sense, I know!).

I figure, why not be explicit?

There is plenty of space for the full word, since the sidebar is hardcoded to
300px as far as I can tell, and in the klipper tab we have a button for "Assisted Bed Leveling", which is significantly longer.