### PR TITLE
Fix switching to the plugin tab with a navbar click broken

### DIFF
--- a/octoprint_klipper/static/js/klipper.js
+++ b/octoprint_klipper/static/js/klipper.js
@@ -81,7 +81,11 @@ $(function() {
               });
            }
         }
-     
+
+        self.navbarClicked = function() {
+            $("#tab_plugin_klipper_main_link").find("a").click();
+        }
+
         self.onGetStatus = function() {
            OctoPrint.control.sendGcode("Status")
         }

--- a/octoprint_klipper/templates/klipper_navbar.jinja2
+++ b/octoprint_klipper/templates/klipper_navbar.jinja2
@@ -1,1 +1,1 @@
-<a href="#tab_plugin_klipper_main" data-bind="text: shortStatus"></a>
+<a data-bind="text: shortStatus, click: navbarClicked"></a>


### PR DESCRIPTION
Closes #23

When there are more tabs to be shown than there is space for them, OctoPrint shows a dropdown icon hiding the excess items. Whenever this is the case, a click on this plugins navbar item does not switch to the OctoKlipper tab but just scrolls the page to the vertical location of the link item.

This behavior is fixed with this PR by using JavaScript for handling the click event.