### PR TITLE
Fix performance graph can't read log with Python 3

### DIFF
--- a/octoprint_klipper/modules/KlipperLogAnalyzer.py
+++ b/octoprint_klipper/modules/KlipperLogAnalyzer.py
@@ -43,7 +43,7 @@ class KlipperLogAnalyzer():
       out = []
 
       try:
-         f = open(logname, 'rb')
+         f = open(logname, 'r')
 
          for line in f:
             parts = line.split()


### PR DESCRIPTION
Closes #21 

With Python 2 it seems that Strings prefixed with b are converted to text strings implicitly:

``` python
>>> s = b'Hello World'
>>> print(s)
Hello World
>>> line = s.split()
>>> print(line)
['Hello', 'World']
>>> if ('Hello' in line):
...     print("true")
... else:
...     print("false")
...
true
```

In Python 3 this is not the case:

``` python
>>> s = b'Hello World'
>>> print(s)
b'Hello World'
>>> line = s.split()
>>> print(line)
[b'Hello', b'World']
>>> if ('Hello' in line):
...     print("true")
... else:
...     print("false")
...
false
```

My approach is to parse the log file in text mode, as I don't understand why it was opened in binary mode in the first place.
I've tested my code with OctoPrint 1.5.1, Python 2.7.18 and Python 3.8.6 on my Windows machine and OctoPrint 1.5.1 and Python 3.9.0 on my Raspberry Pi 3.