### PR TITLE
 Added feature for a horizontal line between macro buttons

### DIFF
--- a/octoprint_klipper/static/css/klipper.css
+++ b/octoprint_klipper/static/css/klipper.css
@@ -13,6 +13,14 @@
    color: #333;
 }
 
+#macros .item { 
+   margin-bottom: 5px;
+   border: 1px solid #ddd;
+   border-radius: 3px;
+   background-color: #eeeeef;
+   color: #333;
+}
+
 .plugin-klipper-log .error {
    background-color: #eebabb;
 }

--- a/octoprint_klipper/static/js/klipper_settings.js
+++ b/octoprint_klipper/static/js/klipper_settings.js
@@ -27,6 +27,15 @@ $(function() {
               tab: true
            });
         }
+
+        self.addLine = function() {
+         self.settings.settings.plugins.klipper.macros.push({
+            name: 'HLine',
+            macro: '',
+            sidebar: true,
+            tab: true
+         });
+        }
         
         self.removeMacro = function(macro) {
            self.settings.settings.plugins.klipper.macros.remove(macro);

--- a/octoprint_klipper/templates/klipper_settings.jinja2
+++ b/octoprint_klipper/templates/klipper_settings.jinja2
@@ -57,7 +57,7 @@
        </div>
     </div>
     <div data-bind="foreach: settings.settings.plugins.klipper.macros">   
-       <div class="control-group">
+       <div class="item">
            <label class="control-label">{{ _('Name') }}</label>
            <div class="controls">
                 <div class="row-fluid">
@@ -77,8 +77,9 @@
                   </div>
                 </div>
            </div>
-           <label class="control-label">{{ _('Command') }}</label>
-           <div class="controls">
+           <!--ko ifnot:name() == "HLine"-->
+             <label class="control-label">{{ _('Command') }}</label>
+             <div class="controls">
                <div class="row-fluid">
                  <div class="span8">
                     <textarea rows="2" class="block" data-bind="value: macro">
@@ -86,12 +87,15 @@
                  </div>
                  <div class="span2"></div>
                </div>
-           </div>
+             </div>
+           <!-- /ko -->
        </div>
     </div>
     <div class="control-group">
       <div class="controls">
         <a href='#' data-bind='click: addMacro' class="fa fa-plus-circle"></a> {{ _('Add Macro') }}
+        <br>
+        <a href='#' data-bind='click: addLine' class="fa fa-plus-circle"></a> {{ _('Add Line') }}
       </div>
     </div>
     <div class="control-group">

--- a/octoprint_klipper/templates/klipper_sidebar.jinja2
+++ b/octoprint_klipper/templates/klipper_sidebar.jinja2
@@ -9,9 +9,20 @@
    <div class="controls">
       <label class="control-label small"><i class="icon-list-alt"></i> {{ _('Macros') }}</label>
       <div data-bind="foreach: settings.settings.plugins.klipper.macros">
-         <!-- ko if: sidebar -->
-         <button class="btn btn-block" data-bind="text: name, click: $parent.executeMacro, enable: $parent.isActive()"></button>
-         <!-- /ko -->
+        <!-- ko if: name() == "HLine" -->
+          <!-- ko if: sidebar -->
+            <hr style="background-color:#B0B0B0;border-width:0;color:#B0B0B0;height:2px;line-height:0;width:80%;margin-left:auto;margin-right:auto;margin-top:0.2em;margin-bottom:0.2em" />
+          <!-- /ko -->
+          <!-- ko ifnot: sidebar -->
+          <!-- /ko -->
+        <!-- /ko -->
+        <!-- ko if: name() != "HLine" -->
+          <!-- ko if: sidebar -->
+           <button class="btn btn-block" data-bind="text: name, click: $parent.executeMacro, enable: $parent.isActive()"></button>
+          <!-- /ko -->
+          <!-- ko ifnot: sidebar -->
+          <!-- /ko -->
+        <!-- /ko -->
       </div>
    </div>
 </div>

--- a/octoprint_klipper/templates/klipper_tab_main.jinja2
+++ b/octoprint_klipper/templates/klipper_tab_main.jinja2
@@ -61,9 +61,19 @@
      <div class="controls">
          <label class="control-label"><i class="icon-list-alt"></i> {{ _('Macros') }}</label>
          <div data-bind="foreach: settings.settings.plugins.klipper.macros">
-            <!-- ko if: tab -->
-            <button class="btn btn-block btn-small" data-bind="text: name, click: $parent.executeMacro, enable: $parent.isActive()">
-            </button>
+           <!-- ko if: name() == "HLine" -->
+             <!-- ko if: tab -->
+               <hr style="background-color:#B0B0B0;border-width:0;color:#B0B0B0;height:2px;line-height:0;width:80%;margin-left:auto;margin-right:auto;margin-top:0.2em;margin-bottom:0.2em" />             
+             <!-- /ko -->
+             <!-- ko ifnot: tab -->
+             <!-- /ko -->
+           <!-- /ko -->
+           <!-- ko if: name() != "HLine" -->
+              <!-- ko if: tab -->
+                <button class="btn btn-block btn-small" data-bind="text: name, click: $parent.executeMacro, enable: $parent.isActive()"></button> 
+              <!-- /ko -->
+              <!-- ko ifnot: tab -->
+              <!-- /ko -->
             <!-- /ko -->
          </div>
      </div>


### PR DESCRIPTION
 This adds a feature for a horizontal line between macro buttons on the sidebar and on the klipper tab. Also worked on the macrolist to distinguish the macros better apart.

One can then just name macros with "HLine" and it will display a `<hr>` line at this position in the list of buttons.
I added a button to insert automatically a new macro with "HLine" as the name.
Also i got borders, like these in the OctoKlipper-log, around the macros in the settings for OctoKlipper to distinguish them better. 

The container-less knockout is only working like that. I tried other things like `<!-- ko if: sidebar && name() != "HLine" -->` But it didn't worked with that.
I also tried to get a whole `<!-- ko if: tab -->` around the other conditions but it didn't work.

I want to say that this is my first ever pull request on github. So bear with me.

closes #27