### PR TITLE
Shortcut to printer.cfg with granulary access

### DIFF
--- a/octoprint_klipper/__init__.py
+++ b/octoprint_klipper/__init__.py
@@ -21,8 +21,10 @@ import glob
 import os
 import sys
 from octoprint.util.comm import parse_firmware_line
+from octoprint.access.permissions import Permissions, ADMIN_GROUP, USER_GROUP
 from .modules import KlipperLogAnalyzer
 import flask
+from flask_babel import gettext
 
 class KlipperPlugin(
       octoprint.plugin.StartupPlugin,
@@ -49,6 +51,17 @@ class KlipperPlugin(
 
    #-- Settings Plugin
 
+   def get_additional_permissions(self, *args, **kwargs):
+        return [
+            dict(key="CONFIG",
+                name="Config Klipper",
+                description=gettext("Allows to config klipper"),
+                default_groups=[ADMIN_GROUP],
+                dangerous=True,
+                roles=["admin"]
+            )
+        ]
+   
    def get_settings_defaults(self):
       return dict(
          connection = dict(
@@ -357,6 +370,7 @@ def __plugin_load__():
    global __plugin_hooks__
    __plugin_implementation__ = KlipperPlugin()
    __plugin_hooks__ = {
+      "octoprint.access.permissions": __plugin_implementation__.get_additional_permissions,
       "octoprint.comm.protocol.gcode.received": __plugin_implementation__.on_parse_gcode,
       "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
    }

--- a/octoprint_klipper/static/js/klipper.js
+++ b/octoprint_klipper/static/js/klipper.js
@@ -22,6 +22,7 @@ $(function() {
         self.connectionState = parameters[2];
         self.levelingViewModel = parameters[3];
         self.paramMacroViewModel = parameters[4];
+        self.access = parameters[5];
         
         self.shortStatus = ko.observable();
         self.logMessages = ko.observableArray();
@@ -127,6 +128,25 @@ $(function() {
         self.isActive = function() {
            return self.connectionState.isOperational() && self.loginState.isUser();
         }
+
+        // OctoKlipper settings link
+        self.openOctoKlipperSettings = function(profile_type) {
+
+         if (
+            !self.loginState.hasPermission(
+                self.access.permissions.PLUGIN_KLIPPER_CONFIG
+            )
+         )
+            return;
+
+         $('a#navbar_show_settings').click();
+         $('li#settings_plugin_klipper_link a').click();
+         if(profile_type)
+         {
+             var query= "#klipper-settings a[data-profile-type='"+profile_type+"']";
+             $(query).click();
+         }
+        };
     }
 
     OCTOPRINT_VIEWMODELS.push({
@@ -136,7 +156,8 @@ $(function() {
            "loginStateViewModel",
            "connectionViewModel",
            "klipperLevelingViewModel",
-           "klipperMacroDialogViewModel"
+           "klipperMacroDialogViewModel",
+           "accessViewModel"
         ],
         elements: ["#tab_plugin_klipper_main", "#sidebar_plugin_klipper", "#navbar_plugin_klipper"]
     });

--- a/octoprint_klipper/templates/klipper_settings.jinja2
+++ b/octoprint_klipper/templates/klipper_settings.jinja2
@@ -1,9 +1,9 @@
 <form class="form-horizontal">
 <ul class="nav nav-pills" id="klipper-settings">
-  <li><a href="#basic" data-toggle="tab">Basic</a></li>
-  <li><a href="#macros" data-toggle="tab">Macros</a></li>
-  <li><a href="#level" data-toggle="tab">Bed Leveling</a></li>
-  <li><a href="#conf" data-toggle="tab">Klipper Configuration</a></li>
+  <li><a href="#basic" data-toggle="tab" data-profile-type="klipper-basic">Basic</a></li>
+  <li><a href="#macros" data-toggle="tab" data-profile-type="klipper-macros">Macros</a></li>
+  <li><a href="#level" data-toggle="tab" data-profile-type="klipper-bed">Bed Leveling</a></li>
+  <li><a href="#conf" data-toggle="tab" data-profile-type="klipper-config">Klipper Configuration</a></li>
 </ul>
 <div class="tab-content">
   <!-- Basics -->

--- a/octoprint_klipper/templates/klipper_sidebar.jinja2
+++ b/octoprint_klipper/templates/klipper_sidebar.jinja2
@@ -7,6 +7,11 @@
 </div>
 <div class="control-group">
    <div class="controls">
+      <button class="btn btn-block" data-bind="visible: loginState.hasPermissionKo(access.permissions.PLUGIN_KLIPPER_CONFIG), click: function() {openOctoKlipperSettings('klipper-config');}">{{ _('Open Klipper config') }}</button>
+   </div>
+</div>
+<div class="control-group">
+   <div class="controls">
       <label class="control-label small"><i class="icon-list-alt"></i> {{ _('Macros') }}</label>
       <div data-bind="foreach: settings.settings.plugins.klipper.macros">
          <!-- ko if: sidebar -->

--- a/octoprint_klipper/templates/klipper_tab_main.jinja2
+++ b/octoprint_klipper/templates/klipper_tab_main.jinja2
@@ -1,6 +1,11 @@
 <div class="row-fluid">
   <div class="span8">
-    <label><i class="icon-tasks"></i> {{ _('Messages') }}</label>
+    <label><i class="icon-tasks"></i> {{ _('Messages') }}
+      <a title="Open printer.cfg" 
+         data-bind="visible: loginState.hasPermissionKo(access.permissions.PLUGIN_KLIPPER_CONFIG), click: function() {openOctoKlipperSettings('klipper-config');}" style="float:right">
+         <i class="fa fa-file-code-o fa-lg"></i> printer.cfg
+      </a>
+    </label>
     <div class="plugin-klipper-log" data-bind="foreach: logMessages">
       <div class="log-item" data-bind="css: type">
          <div data-bind="text: time" class="ts" ></div>

--- a/octoprint_klipper/templates/klipper_tab_main.jinja2
+++ b/octoprint_klipper/templates/klipper_tab_main.jinja2
@@ -1,77 +1,76 @@
 <div class="row-fluid">
-  <div class="span8">
-    <label><i class="icon-tasks"></i> {{ _('Messages') }}
-      <a title="Open printer.cfg" 
-         data-bind="visible: loginState.hasPermissionKo(access.permissions.PLUGIN_KLIPPER_CONFIG), click: function() {openOctoKlipperSettings('klipper-config');}" style="float:right">
-         <i class="fa fa-file-code-o fa-lg"></i> printer.cfg
-      </a>
-    </label>
-    <div class="plugin-klipper-log" data-bind="foreach: logMessages">
-      <div class="log-item" data-bind="css: type">
-         <div data-bind="text: time" class="ts" ></div>
-         <div data-bind="html: msg" class="msg"></div>
-      </div>
-    </div>
-    &nbsp;
-    <button class="btn btn-mini pull-right clear-btn" data-bind="click: onClearLog, enable: isActive()"
-       title="Clear Log">
-       <i class="fa fa-trash"></i>{{ _('Clear') }}
-    </button>
-  </div>
-  <div class="span4">
-    <div class="control-group">
-     <div class="control-group">
-        <div class="controls">
-           <label class="control-label"></label>
-           <button class="btn btn-block btn-small" data-bind="click: onGetStatus, enable: isActive()"
-              title="Query Klipper for its current status">
-              <i class="fa icon-black fa-info-circle"></i> {{ _('Get Status') }}
-           </button>
-        </div>
-     </div>
-     <div class="control-group">
-        <div class="controls">
-          <label class="control-label small"><i class="icon-refresh"></i> {{ _('Restart') }}</label>
-          <button class="btn btn-block btn-small" data-bind="click: onRestartHost, enable: isActive()"
-             title="This will cause the host software to reload its config and perform an internal reset">
-             {{ _('Host') }}
-          </button>
-          <button class="btn btn-block btn-small" data-bind="click: onRestartFirmware, enable: isActive()"
-             title="Similar to a host restart, but also clears any error state from the micro-controller">
-             {{ _('Firmware') }}
-          </button>
-        </div>
-     </div>
-     <div class="control-group">
-        <div class="controls">
-         <label class="control-label"><i class="icon-wrench"></i> {{ _('Tools') }}</label>
-         <button class="btn btn-block btn-small" data-bind="click: showLevelingDialog, enable: isActive()"
-            title="Assists in manually leveling your printbed by moving the head to a configurable set of positions in sequence.">
-            {{ _('Assisted Bed Leveling') }}
-         </button>
-         <button class="btn btn-block btn-small" data-bind="click: showPidTuningDialog, enable: isActive()"
-            title="Determines optimal PID parameters by heat cycling the hotend/bed.">
-            {{ _('PID Tuning') }}
-         </button>
-         <button class="btn btn-block btn-small" data-bind="click: showOffsetDialog, enable: isActive()"
-            title="Sets a offset for subsequent GCODE coordinates.">
-            {{ _('Coordinate Offset') }}
-         </button>
-         <button class="btn btn-block btn-small" data-bind="click: showGraphDialog, enable: isActive()"
-            title="Assists in debugging performance issues by analyzing the Klipper log files.">
-            {{ _('Performance Graph') }}
-         </button>
-        </div>
-     </div>
-     <div class="controls">
-         <label class="control-label"><i class="icon-list-alt"></i> {{ _('Macros') }}</label>
-         <div data-bind="foreach: settings.settings.plugins.klipper.macros">
-            <!-- ko if: tab -->
-            <button class="btn btn-block btn-small" data-bind="text: name, click: $parent.executeMacro, enable: $parent.isActive()">
-            </button>
-            <!-- /ko -->
+   <div class="span8">
+      <label>
+         <i class="icon-tasks"></i> {{ _('Messages') }}
+      </label>
+      <div class="plugin-klipper-log" data-bind="foreach: logMessages">
+         <div class="log-item" data-bind="css: type">
+            <div data-bind="text: time" class="ts"></div>
+            <div data-bind="html: msg" class="msg"></div>
          </div>
-     </div>
-    </div>
-  </div>
+      </div>
+      &nbsp;
+      <button class="btn btn-mini pull-right clear-btn" data-bind="click: onClearLog, enable: isActive()"
+         title="Clear Log">
+         <i class="fa fa-trash"></i> {{ _('Clear') }}
+      </button>
+   </div>
+   <div class="span4">
+      <div class="control-group">
+         <div class="control-group">
+            <div class="controls">
+               <label class="control-label"></label>
+               <button class="btn btn-block btn-small" data-bind="click: onGetStatus, enable: isActive()" title="Query Klipper for its current status">
+                  <i class="fa icon-black fa-info-circle"></i> {{ _('Get Status') }}
+               </button>
+               <button class="btn btn-block btn-small" data-bind="visible: loginState.hasPermissionKo(access.permissions.PLUGIN_KLIPPER_CONFIG), click: function() {openOctoKlipperSettings('klipper-config');}" title="Open the Klipper configurationfile">
+                  <i class="fa icon-black fa-file-code-o"></i> {{ _('Open Klipper config') }}
+               </button>
+            </div>
+         </div>
+         <div class="control-group">
+            <div class="controls">
+               <label class="control-label small"><i class="icon-refresh"></i> {{ _('Restart') }}</label>
+               <button class="btn btn-block btn-small" data-bind="click: onRestartHost, enable: isActive()"
+                  title="This will cause the host software to reload its config and perform an internal reset">
+                  {{ _('Host') }}
+               </button>
+               <button class="btn btn-block btn-small" data-bind="click: onRestartFirmware, enable: isActive()"
+                  title="Similar to a host restart, but also clears any error state from the micro-controller">
+                  {{ _('Firmware') }}
+               </button>
+            </div>
+         </div>
+         <div class="control-group">
+            <div class="controls">
+               <label class="control-label"><i class="icon-wrench"></i> {{ _('Tools') }}</label>
+               <button class="btn btn-block btn-small" data-bind="click: showLevelingDialog, enable: isActive()"
+                  title="Assists in manually leveling your printbed by moving the head to a configurable set of positions in sequence.">
+                  {{ _('Assisted Bed Leveling') }}
+               </button>
+               <button class="btn btn-block btn-small" data-bind="click: showPidTuningDialog, enable: isActive()"
+                  title="Determines optimal PID parameters by heat cycling the hotend/bed.">
+                  {{ _('PID Tuning') }}
+               </button>
+               <button class="btn btn-block btn-small" data-bind="click: showOffsetDialog, enable: isActive()"
+                  title="Sets a offset for subsequent GCODE coordinates.">
+                  {{ _('Coordinate Offset') }}
+               </button>
+               <button class="btn btn-block btn-small" data-bind="click: showGraphDialog, enable: isActive()"
+                  title="Assists in debugging performance issues by analyzing the Klipper log files.">
+                  {{ _('Performance Graph') }}
+               </button>
+            </div>
+         </div>
+         <div class="controls">
+            <label class="control-label"><i class="icon-list-alt"></i> {{ _('Macros') }}</label>
+            <div data-bind="foreach: settings.settings.plugins.klipper.macros">
+               <!-- ko if: tab -->
+                  <button class="btn btn-block btn-small" data-bind="text: name, click: $parent.executeMacro, enable: $parent.isActive()">
+                  </button>
+               <!-- /ko -->
+            </div>
+         </div>
+      </div>
+   </div>
 </div>


### PR DESCRIPTION
closes #19 

This displays a link, if someone is allowed to config klipper, on the klipper tab for the printer.cfg,
It opens directly the plugin tab for OctoKlipper with the tab "Klipper Configuration".
I tested it with a new user i made with only "Read-only Access". This user wouldn't then even see the link for the printer.cfg on the tab.

We can also add this function for all the other things that are displayed now but shouldn't if someone has no access for them. Like the list of macros for example.
![Screenshot 2021-01-13 003237](https://user-images.githubusercontent.com/12502210/104387198-e300af80-5536-11eb-812c-71c6ae61a1e0.jpg)
