### PR TITLE
Fix for overflow of textarea for the klipperconfig file.

### DIFF
--- a/octoprint_klipper/static/css/klipper.css
+++ b/octoprint_klipper/static/css/klipper.css
@@ -40,6 +40,50 @@
    font-family: monospace;
 }
 
+ul#klipper-settings { 
+   margin: 0;
+   /* height: 5%; */
+}
+
+#klipper-settings a{ 
+   margin: 5px;
+}
+
+#settings_plugin_klipper {
+   height: 100%;
+}
+
+#settings_plugin_klipper .form-horizontal{
+   margin: 0px;
+   height: 100%;
+}
+
+#settings_plugin_klipper .tab-content{
+   height: calc(100% - 40px);
+}
+
+#conf {
+   height:100%;
+}
+
+#conf textarea {
+   height: 100%;
+   resize: none;
+}
+
+#conf .control-group {
+   margin-bottom: 0px;
+   height: 99%;
+}
+
+#level .add-on {
+   padding: 5px;
+}
+
+#level .controls {
+   padding: 1px;
+}
+
 #klipper_graph_dialog form {
 	margin: 0;
 }

--- a/octoprint_klipper/templates/klipper_settings.jinja2
+++ b/octoprint_klipper/templates/klipper_settings.jinja2
@@ -189,7 +189,8 @@ WRITE_FILE={label:Write to File, default:0, options:0|1}
   <!-- Klipper Conf -->
   <div class="tab-pane" id="conf">
    <div class="control-group">
-      <textarea id="plugin-klipper-config" rows="31" class="block" data-bind="value: settings.settings.plugins.klipper.config"></textarea>
+      <textarea id="plugin-klipper-config" class="block" data-bind="value: settings.settings.plugins.klipper.config"></textarea>
+
    </div>
   </div>
 </div>


### PR DESCRIPTION
Keep textarea for klipperconfig in the parent div.
That was fiddling to do.

fixes #17 