### PR TITLE
Switch for navbar messages

### DIFF
--- a/octoprint_klipper/__init__.py
+++ b/octoprint_klipper/__init__.py
@@ -75,7 +75,8 @@ class KlipperPlugin(
          configuration = dict(
             configpath="~/printer.cfg",
             logpath="/tmp/klippy.log",
-            reload_command="RESTART"
+            reload_command="RESTART",
+            navbar=True
          )
       )
 

--- a/octoprint_klipper/templates/klipper_navbar.jinja2
+++ b/octoprint_klipper/templates/klipper_navbar.jinja2
@@ -1,1 +1,3 @@
-<a data-bind="text: shortStatus, click: navbarClicked"></a>
+<!-- ko if: settings.settings.plugins.klipper.configuration.navbar -->
+    <a data-bind="text: shortStatus, click: navbarClicked"></a>
+<!-- /ko -->

--- a/octoprint_klipper/templates/klipper_settings.jinja2
+++ b/octoprint_klipper/templates/klipper_settings.jinja2
@@ -19,6 +19,11 @@
         <div class="controls">
             <input type="checkbox" class="input-block-level" data-bind="checked: settings.settings.plugins.klipper.connection.replace_connection_panel">
         </div>
+    </div><div class="control-group">
+        <label class="control-label">{{ _('Show NavBar Message') }}</label>
+        <div class="controls">
+            <input type="checkbox" class="input-block-level" data-bind="checked: settings.settings.plugins.klipper.configuration.navbar">
+        </div>
     </div>
     <div class="control-group">
         <label class="control-label">{{ _('Klipper Config Path') }}</label>


### PR DESCRIPTION
closes #32

With this commit you can turn the navbar messages on/off.
Checkbox for this is on the "Basic" tab for OctoKlipper.
![klipper_navbar_switch](https://user-images.githubusercontent.com/12502210/107026736-6fefff00-67ab-11eb-9b75-24d6be864a40.png)
